### PR TITLE
debugger: operate on prebuilt binaries with exec command

### DIFF
--- a/debugger.go
+++ b/debugger.go
@@ -372,7 +372,7 @@ func (d *Debugger) Stop() {
 func (d *Debugger) Restart() {
 	d.Stop()
 
-	_, err := d.Debugger.Restart(false, "", false, []string{}, [3]string{}, true)
+	_, err := d.Debugger.Restart(false, "", false, []string{}, [3]string{}, !d.PreBuilt)
 	if err != nil {
 		log.Printf("Error restarting: %s", err)
 		return

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	cmdAndArgs := os.Args[1:]
 	if len(cmdAndArgs) == 0 {
-		log.Fatalln("debugger needs a command: `run` or `test`")
+		log.Fatalln("debugger needs a command: `run`, `exec` or `test`")
 	}
 
 	cmd := cmdAndArgs[0]
@@ -33,7 +33,19 @@ func main() {
 		args = cmdAndArgs[1:]
 	}
 
-	debugger, err := NewDebugger("debug", args, true, cmd == "test")
+	bin := "debug"
+
+	switch cmd {
+	case "run":
+	case "test":
+	case "exec":
+		bin = args[0]
+		args = args[1:]
+	default:
+		log.Fatalln("invalid command: ", cmd)
+	}
+
+	debugger, err := NewDebugger(bin, args, true, cmd == "test", cmd == "exec")
 	if err != nil {
 		log.Fatalln(err.Error())
 	}


### PR DESCRIPTION
This command skips the compile step and uses the named binary directly.

We add a new command `exec` that accepts a prebuilt binary name and skips the compile step. 

Closes #6 